### PR TITLE
[hotfix] 여권 생성 쿼리 수정

### DIFF
--- a/src/main/resources/mapper/passport/PassportQueryMapper.xml
+++ b/src/main/resources/mapper/passport/PassportQueryMapper.xml
@@ -43,13 +43,18 @@
                r.name    AS roastery_name
         FROM visits v
                  INNER JOIN menus m ON v.menu_id = m.id
-                 LEFT JOIN menu_bean_mappings mbm ON m.id = mbm.menu_id
-                 LEFT JOIN beans b ON mbm.bean_id = b.id
+                 LEFT JOIN (
+                     SELECT menu_id, MIN(bean_id) AS min_bean_id
+                     FROM menu_bean_mappings
+                     GROUP BY menu_id
+                 ) min_mbm ON m.id = min_mbm.menu_id
+                 LEFT JOIN beans b ON min_mbm.min_bean_id = b.id
                  LEFT JOIN roasteries r ON b.roastery_id = r.id
         WHERE v.user_id = #{userId}
           AND YEAR(v.created_at) = #{year}
           AND MONTH(v.created_at) = #{month}
           AND v.menu_id IS NOT NULL
+          AND v.is_verified = true
         ORDER BY v.created_at ASC
     </select>
 

--- a/src/main/resources/mapper/passport/PassportRecordQueryMapper.xml
+++ b/src/main/resources/mapper/passport/PassportRecordQueryMapper.xml
@@ -11,7 +11,7 @@
                s.name         AS store_name,
                s.address      AS store_address,
                s.latitude     AS latitude,
-               s.longitude    AS longitube,
+               s.longitude    AS longitude,
                MAX(b.country) AS bean_origin,
                m.name         AS menu_name
         FROM passport_visits pv


### PR DESCRIPTION
## 문제
1. 메뉴에 2개 이상 원두 매핑되어있을 시 중복 키 오류
LEFT JOIN menu_bean_mappings mbm ON m.id = mbm.menu_id
  LEFT JOIN beans b ON mbm.bean_id = b.id
  → 한 메뉴에 원두가 2개 매핑되어 있으면 같은 visit_id가 2행으로 반환
  → for문 돌면서 INSERT INTO passport_visits (passport_id, visit_id) 2번 실행
  → Duplicate key 오류

2. 방문인증 실패한 것도 모두 여권에 포함됨
3. 쿼리 내 오타 

## 수정사항
  - 메뉴에 여러 원두 매핑 시 MIN bean_id로 1개만 선택하도록 수정
    ->  visits, reviews에 bean_id 칼럼 추가가 필요하다고 판단했지만, 한시가 급하니 일단 당장 작동을 위해 이렇게 수정했습니다.
  - 인증된 방문(is_verified = true)만 여권에 포함되도록 수정
  - longitude 오타 수정 (longitube → longitude)
